### PR TITLE
Add suport for navigation section customization

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -21,8 +21,20 @@
                 "notes": "Hides Foundry logo in upper left corner of the screen"
             },
             "hide-navigation": {
-                "label": "Hide navigation tiles",
-                "notes": "Hides navigation tiles across top of screen"
+                "sub-options-label": "Or hide specific parts of the navigation section - Overridden by Hide Navigation Section setting",
+                "complete": {
+                    "label": "Hide Navigation Section",
+                    "notes": "Hides navigation section across top of screen"
+                },
+                "navToggle": {
+                    "label": "Navigation Toggle"
+                },
+                "sceneList": {
+                    "label": "Scene List"
+                },
+                "bossBar": {
+                    "label": "Boss Bar"
+                }
             },
             "hide-controls": {
                 "label": "Hide Controls",

--- a/module.json
+++ b/module.json
@@ -9,9 +9,9 @@
         "url": "https://github.com/gsimon2"
       }
     ],
-    "version": "1.2.0",
-    "minimumCoreVersion": "0.7.0",
-    "compatibleCoreVersion": "0.7.9",
+    "version": "1.3.0",
+    "minimumCoreVersion": "0.8.0",
+    "compatibleCoreVersion": "0.8.9",
     "esmodules": ["scripts/hide-player-ui.js"],
     "styles": ["styles/hide-player-ui.css"],
     "languages": [
@@ -24,7 +24,7 @@
     "url": "https://github.com/gsimon2/hide-player-ui",
     "bugs": "https://github.com/gsimon2/hide-player-ui/issues",
     "changelog": "https://github.com/gsimon2/hide-player-ui/releases",
-    "download": "https://github.com/gsimon2/hide-player-ui/releases/download/1.2.0/module.zip",
-    "manifest": "https://github.com/gsimon2/hide-player-ui/releases/download/1.2.0/module.json",
+    "download": "https://github.com/gsimon2/hide-player-ui/releases/download/1.3.0/module.zip",
+    "manifest": "https://github.com/gsimon2/hide-player-ui/releases/download/1.3.0/module.json",
     "readme": "https://raw.githubusercontent.com/gsimon2/hide-player-ui/main/README.md"
   }

--- a/scripts/hide-player-ui.js
+++ b/scripts/hide-player-ui.js
@@ -24,8 +24,12 @@ Hooks.on('ready', () => {
             hideElement('logo');
         }
 
-        if (settings.hideNavigation) {
+        if (settings.hideNavigation.complete) {
             hideElement('navigation');
+        } else {
+            settings.hideNavigation.navToggle && hideElement('navToggle');
+            settings.hideNavigation.sceneList && hideElement('sceneList');
+            settings.hideNavigation.bossBar && hideElement('bossBar');
         }
 
         if (settings.hideControls) {

--- a/scripts/settings-form.js
+++ b/scripts/settings-form.js
@@ -14,8 +14,10 @@ export class HidePlayerUISettingsForm extends FormApplication {
     getData(options) {
         const moduleSpecificData = {
             renderTokenActionHudOption: game.modules.get('token-action-hud') && game.modules.get('token-action-hud').active,
-            rednerCustomHotbarOption: game.modules.get('custom-hotbar') && game.modules.get('custom-hotbar').active
+            renderCustomHotbarOption: game.modules.get('custom-hotbar') && game.modules.get('custom-hotbar').active,
+            renderBossBarOption: game.modules.get('bossbar') && game.modules.get('bossbar').active
         };
+        console.log(game.modules)
         const data = mergeObject(moduleSpecificData, this.reset ? defaultSettings : game.settings.get('hide-player-ui', 'settings'));
         return data;
     }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -2,19 +2,24 @@ import {HidePlayerUISettingsForm} from './settings-form.js';
 
 export const defaultSettings = {
     hideLogo: true,
-    hideNavigation: true,
+    hideNavigation: {
+        complete: true,
+        navToggle: true,
+        sceneList: true,
+        bossBar: true
+    },
     hideControls: true,
     hideSideBar: {
         complete: true,
-        chatLog: false,
-        combatTracker: false,
-        actorsDirectory: false,
-        itemsDirectory: false,
-        journalEntries: false,
-        rollableTables: false,
-        audioPlaylists: false,
-        compendiumPacks: false,
-        gameSettings: false
+        chatLog: true,
+        combatTracker: true,
+        actorsDirectory: true,
+        itemsDirectory: true,
+        journalEntries: true,
+        rollableTables: true,
+        audioPlaylists: true,
+        compendiumPacks: true,
+        gameSettings: true
     },
     hidePlayers: true,
     hideHotbar: true,

--- a/styles/hide-player-ui.css
+++ b/styles/hide-player-ui.css
@@ -20,6 +20,18 @@
     display: none !important;
 }
 
+.hide-player-ui-navToggle #nav-toggle {
+    display: none !important;
+}
+
+.hide-player-ui-sceneList #scene-list {
+    display: none !important;
+}
+
+.hide-player-ui-bossBar .bossBar {
+    display: none !important;
+}
+
 .hide-player-ui-controls #controls {
     display: none !important;
 }

--- a/templates/settings-form.html
+++ b/templates/settings-form.html
@@ -7,10 +7,33 @@
             <p class="notes">{{localize "hide-player-ui.settings-form.hide-logo.notes"}}</p>
         </div>
 
-        <div class="form-group">
-            <label>{{localize "hide-player-ui.settings-form.hide-navigation.label"}}</label>
-            <input type="checkbox" name="hideNavigation" data-dtype="Boolean" {{checked hideNavigation}}/>
-            <p class="notes">{{localize "hide-player-ui.settings-form.hide-navigation.notes"}}</p>
+        <div>
+            <div class="form-group">
+                <label>{{localize "hide-player-ui.settings-form.hide-navigation.complete.label"}}</label>
+                <input type="checkbox" name="hideNavigation.complete" data-dtype="Boolean" {{checked hideNavigation.complete}}/>
+                <p class="notes">{{localize "hide-player-ui.settings-form.hide-navigation.complete.notes"}}</p>
+            </div>
+
+            <p class="notes notes-second-line">{{localize "hide-player-ui.settings-form.hide-navigation.sub-options-label"}}</p>
+
+            <div class="sub-option-grouping">
+                <div class="form-group">
+                    <label>{{localize "hide-player-ui.settings-form.hide-navigation.navToggle.label"}}</label>
+                    <input type="checkbox" name="hideNavigation.navToggle" data-dtype="Boolean" {{checked hideNavigation.navToggle}}/>
+                </div>
+
+                <div class="form-group">
+                    <label>{{localize "hide-player-ui.settings-form.hide-navigation.sceneList.label"}}</label>
+                    <input type="checkbox" name="hideNavigation.sceneList" data-dtype="Boolean" {{checked hideNavigation.sceneList}}/>
+                </div>
+
+                {{#if renderBossBarOption}}
+                    <div class="form-group">
+                        <label>{{localize "hide-player-ui.settings-form.hide-navigation.bossBar.label"}}</label>
+                        <input type="checkbox" name="hideNavigation.bossBar" data-dtype="Boolean" {{checked hideNavigation.bossBar}}/>
+                    </div>
+                {{/if}}
+            </div>
         </div>
 
         <div class="form-group">
@@ -102,7 +125,7 @@
             </div>
         {{/if}}
         
-        {{#if rednerCustomHotbarOption}}
+        {{#if renderCustomHotbarOption}}
             <div class="form-group">
                 <label>{{localize "hide-player-ui.settings-form.hide-custom-hotbar.label"}}</label>
                 <input type="checkbox" name="hideCustomHotbar" data-dtype="Boolean" {{checked hideCustomHotbar}}/>


### PR DESCRIPTION
This allows the boss bar mod to be optionally toggled seperatly from the rest of the navigation section.

Fixes: https://github.com/gsimon2/hide-player-ui/issues/10