### PR TITLE
Add css selector setting to specify hidden elements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -118,6 +118,10 @@
             "hide-custom-hotbar": {
                 "label": "Hide Custom Hotbar",
                 "notes": "Hides custom hotbar across bottom of screen from the Custom Hotbar module"
+            },
+            "hide-css-by-css-selector": {
+               "label": "Hide By CSS Selectors",
+               "notes": "Hides elements specified by CSS selectors. Multiple selectors should be delimited by a semi-colon (;)"
             }
         }
     }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -118,6 +118,10 @@
             "hide-custom-hotbar": {
                 "label": "カスタムホットバーを隠す",
                 "notes": "「Custom Hotbar」MODから画面下部のカスタムホットバーを非表示にします。"
+            },
+            "hide-css-by-css-selector": {
+               "label": "CSSセレクターで隠す",
+               "notes": "CSS セレクターで指定された要素を非表示にします。複数のセレクターはセミコロン (;) で区切る必要があります。"
             }
         }
     }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -31,6 +31,7 @@ export const defaultSettings = {
    hideTokenHUD: false,
    hideTokenActionHUD: true,
    hideCustomHotbar: true,
+   customSelectors: ''
 };
 
 export const defaultPlayerConfig = {
@@ -63,6 +64,7 @@ export const defaultPlayerConfig = {
    hideTokenHUD: false,
    hideTokenActionHUD: false,
    hideCustomHotbar: false,
+   customSelectors: ''
 };
 
 export const registerSettings = () => {

--- a/templates/player-configuration-form.html
+++ b/templates/player-configuration-form.html
@@ -419,6 +419,25 @@
       </div>
       {{/unless}} {{/if}}
 
+      <div class="form-group">
+         <label
+            >{{localize
+            "hide-player-ui.settings-form.hide-css-by-css-selector.label"}}</label
+         >
+         <p class="notes">
+            {{localize
+            "hide-player-ui.settings-form.hide-css-by-css-selector.notes"}}
+         </p>
+         <textarea
+            name="customSelectors"
+            data-dtype="string"
+            rows="4"
+            cols="50"
+         >
+            {{~{playerConfiguration.customSelectors}~}}
+         </textarea>
+      </div>
+
       <div class="warning-note">
          <p>
             {{localize "hide-player-ui.settings-form.refresh-player-sessions"}}

--- a/templates/settings-form.html
+++ b/templates/settings-form.html
@@ -431,6 +431,25 @@
       </div>
       {{/if}}
 
+      <div class="form-group">
+         <label
+            >{{localize
+            "hide-player-ui.settings-form.hide-css-by-css-selector.label"}}</label
+         >
+         <p class="notes">
+            {{localize
+            "hide-player-ui.settings-form.hide-css-by-css-selector.notes"}}
+         </p>
+         <textarea
+            name="customSelectors"
+            data-dtype="string"
+            rows="4"
+            cols="50"
+         >
+            {{~{customSelectors}~}}
+         </textarea>
+      </div>
+
       <div class="warning-note">
          <p>
             {{localize "hide-player-ui.settings-form.refresh-player-sessions"}}


### PR DESCRIPTION
Allows users to provide a list of CSS selectors to specify which elements should be hidden.

Addresses: https://github.com/gsimon2/hide-player-ui/issues/51

Addresses: https://github.com/gsimon2/hide-player-ui/issues/30