### PR TITLE
Fix an issue where the GM would be considered a player.

### DIFF
--- a/scripts/isGM.js
+++ b/scripts/isGM.js
@@ -1,5 +1,21 @@
 export const isGmOrAssistant = () => {
+    // If the user is the GM, then automatically return, no need to check any settings.
+    if (game.user.isGM) {
+        return true;
+    }
+
+    // The user might be an assistant, but the GM might want to hide menus from the assistant
     const hideForAssistantGM = game.settings.get("hide-player-ui", "hideForAssistantGM");
+    if (hideForAssistantGM) {
+        return false;
+    }
+
+    // Else If the user is an assistant, all good.
     const isUserAssistant = game.user.hasRole('ASSISTANT');
-    return game.user.isGM && (!hideForAssistantGM || !isUserAssistant);
+    if (isUserAssistant) {
+        return true;
+    }
+
+    // Else, it is a player.
+    return false;
 }


### PR DESCRIPTION
I've just purchased Foundry and found your module pretty nice, it works exactly like it should ... except if you attempt to login in 

# Issue
The following issue:
https://github.com/gsimon2/hide-player-ui/issues/46

I've just installed your module, set up my player's permission but then when I connected as a GM oops, nothing. As if I was a player.

# Solution

That boolean check was wrong it was:

> true (isGM) && (!true || !true)
> true && (false || false)
> true && false
> false

I've used the Return Early principle to try to narrow down the most traverse code path, let me know if you need me to remove the comments.